### PR TITLE
Antenna simulators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,23 @@
 Changelog
 =========
 
+v0.3.0
+======
+Added
+-----
+* TOML file for antenna simulators
+* Access to all Resistance metadata via a structured numpy array `raw_data`.
+* Antenna simulators are now able to be identified and read in more easily from each component.
+
+Changed
+-------
+* Better way of getting the version
+* Ignore some more different kinds of files.
+
+Fixed
+-----
+* New checks on whether antenna simulators are the same for S11, Spectra and Resistance.
+
 v0.2.0
 ======
 

--- a/src/edges_io/__init__.py
+++ b/src/edges_io/__init__.py
@@ -2,9 +2,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-    # Change here if project is renamed and does not equal the package name
-    dist_name = "edges-io"
-    __version__ = get_distribution(dist_name).version
+    __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     __version__ = "unknown"
 finally:

--- a/src/edges_io/data/__init__.py
+++ b/src/edges_io/data/__init__.py
@@ -1,0 +1,3 @@
+from os import path
+
+DATA_PATH = path.abspath(__file__)

--- a/src/edges_io/data/__init__.py
+++ b/src/edges_io/data/__init__.py
@@ -1,3 +1,3 @@
 from os import path
 
-DATA_PATH = path.abspath(__file__)
+DATA_PATH = path.dirname(path.abspath(__file__))

--- a/src/edges_io/data/antenna_simulators.toml
+++ b/src/edges_io/data/antenna_simulators.toml
@@ -1,0 +1,11 @@
+[AntSim1]
+kind = "passive"
+
+[AntSim2]
+kind = "passive"
+
+[AntSim3]
+kind = "passive"
+
+[AlanNoiseSource]
+kind = "active"

--- a/src/edges_io/data/antenna_simulators.toml
+++ b/src/edges_io/data/antenna_simulators.toml
@@ -1,11 +1,39 @@
 [AntSim1]
 kind = "passive"
+misspells = [
+    'antsim1',
+    'AntSim01'
+]
 
 [AntSim2]
 kind = "passive"
+misspells = [
+    'antsim2',
+    'AntSim02'
+]
 
 [AntSim3]
 kind = "passive"
+misspells = [
+    'antsim3',
+    'AntSim03'
+]
 
-[AlanNoiseSource]
+[AntSim4]
+kind = "passive"
+misspells = [
+    'antsim4',
+    'AntSim04'
+]
+
+[AlanNoiseSource_3db]
 kind = "active"
+misspells = [
+    'AllanNoiseSource_3db',
+]
+
+[AlanNoiseSource_6db]
+kind = "active"
+misspells = [
+    'AllanNoiseSource_6db',
+]

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -79,6 +79,7 @@ class _DataContainer(ABC):
 
         # For a container, if the checks failed, then we ought to bow out now
         if logger.errored:
+            logger.errored = False
             raise utils.FileStructureError()
 
     @classmethod
@@ -573,9 +574,10 @@ class Resistance(_SpectrumOrResistance):
 
     supported_formats = ("csv",)
 
-    def __init__(self, path, fix=False):
+    def __init__(self, path, fix=False, store_data=True):
         super(Resistance, self).__init__(path, fix=fix)
         self.path = self.path[0]
+        self.store_data = store_data
 
     @classmethod
     def check_self(cls, path, fix=False):
@@ -592,7 +594,44 @@ class Resistance(_SpectrumOrResistance):
         return "csv"
 
     def read(self):
-        return np.genfromtxt(self.path, skip_header=1, delimiter=",")[:, -3]
+        try:
+            return self._data
+        except AttributeError:
+            data = np.genfromtxt(
+                self.path,
+                skip_header=1,
+                delimiter=",",
+                dtype=np.dtype(
+                    [
+                        ("date", "S10"),
+                        ("time", "S8"),
+                        ("lna_voltage", np.float),
+                        ("lna_resistance", np.float),
+                        ("lna_temp", np.float),
+                        ("sp4t_voltage", np.float),
+                        ("sp4t_resistance", np.float),
+                        ("sp4t_temp", np.float),
+                        ("load_voltage", np.float),
+                        ("load_resistance", np.float),
+                        ("load_temp", np.float),
+                        ("room_temp", np.float),
+                    ]
+                ),
+            )
+
+            if self.store_data:
+                self._data = data
+
+            return data
+
+    @property
+    def raw_data(self):
+        """The raw csv data of the Resistance measurement.
+
+        Note that this is only cached in memory if `store_data` is True, otherwise
+        the data is re-read from disk each time `raw_data` is accessed.
+        """
+        return self.read()
 
 
 class _SpectraOrResistanceFolder(_DataContainer):
@@ -614,6 +653,13 @@ class _SpectraOrResistanceFolder(_DataContainer):
                 self._content_type.from_load(
                     load, path, run_nums.get(load, None), filetype
                 ),
+            )
+
+        # Populate simulators.
+        self.simulators = {}
+        for name in self.get_simulator_names(self.path):
+            self.simulators[name] = self._content_type.from_load(
+                name, self.path, run_nums.get(name, None), filetype
             )
 
     @classmethod
@@ -640,6 +686,17 @@ class _SpectraOrResistanceFolder(_DataContainer):
                         cls.__name__, load
                     )
                 )
+
+    @classmethod
+    def get_all_load_names(cls, path):
+        """Get all load names found in the Spectra directory"""
+        fls = utils.get_active_files(path)
+        return {os.path.basename(fl).split("_")[0] for fl in fls}
+
+    @classmethod
+    def get_simulator_names(cls, path):
+        load_names = cls.get_all_load_names(path)
+        return {name for name in load_names if name in ANTENNA_SIMULATORS}
 
     @classmethod
     def _check_file_consistency(cls, path):
@@ -818,7 +875,9 @@ class _S11SubDir(_DataContainer):
         if match is None:
             logger.error(
                 "The folder {} did not match any of the correct folder name "
-                "criteria".format(path)
+                "criteria. Required pattern: {} [class={}]".format(
+                    path, cls.folder_pattern, cls.__name__
+                )
             )
 
             if fix:
@@ -1002,6 +1061,12 @@ class S11Dir(_DataContainer):
                 LoadS11(os.path.join(path, load), run_num=run_nums.get(load, None)),
             )
 
+        self.simulators = {}
+        for name in self.get_simulator_names(path):
+            self.simulators[name] = AntSimS11(
+                os.path.join(path, name), run_num=run_nums.get(name, None)
+            )
+
     @classmethod
     def _get_highest_rep_num(cls, path, kind):
         fls = utils.get_active_files(os.path.join(path))
@@ -1033,18 +1098,24 @@ class S11Dir(_DataContainer):
 
     @classmethod
     def _check_file_consistency(cls, path):
-        fls = utils.get_active_files(path)
-        logger.info(
-            "Found the following Antenna Simulators in S11: {}".format(
-                [
-                    os.path.basename(fl)
-                    for fl in fls
-                    if any(
-                        os.path.basename(fl).startswith(k) for k in ANTENNA_SIMULATORS
-                    )
-                ]
+        simulators = cls.get_simulator_names(path)
+        if simulators:
+            logger.info(
+                "Found the following Antenna Simulators in S11: {}".format(
+                    ",".join(simulators)
+                )
             )
-        )
+        else:
+            logger.info("No Antenna Simulators in S11.")
+
+    @classmethod
+    def get_simulator_names(cls, path):
+        fls = utils.get_active_files(path)
+        return {
+            os.path.basename(fl)
+            for fl in fls
+            if any(os.path.basename(fl).startswith(k) for k in ANTENNA_SIMULATORS)
+        }
 
 
 class CalibrationObservation(_DataContainer):
@@ -1096,6 +1167,8 @@ class CalibrationObservation(_DataContainer):
             repeat_num=repeat_num,
             fix=fix,
         )
+
+        self.simulator_names = self.get_simulator_names(self.path)
 
     @classmethod
     def check_self(cls, path, fix=False):
@@ -1188,7 +1261,27 @@ class CalibrationObservation(_DataContainer):
 
     @classmethod
     def _check_file_consistency(cls, path):
-        pass
+        cls.get_simulator_names(
+            path
+        )  # checks whether simulators are the same between each.
+
+    @classmethod
+    def get_simulator_names(cls, path):
+        # Go through the subdirectories and check their simulators
+        dct = {
+            name: tuple(sorted(kls.get_simulator_names(os.path.join(path, name))))
+            for name, kls in cls._content_type.items()
+        }
+
+        # If any list of simulators is not the same as the others, make an error.
+        if len(set(dct.values())) != 1:
+            logger.error(
+                "Antenna Simulators do not match in all subdirectories. Got {}".format(
+                    dct
+                )
+            )
+
+        return set(list(dct.values())[0])
 
     def read_all(self):
         """Read all spectra and resistance files."""

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -1062,7 +1062,7 @@ class CalibrationObservation(_DataContainer):
         if ambient_temp not in [15, 25, 35]:
             raise ValueError("ambient temp must be one of 15, 25, 35!")
 
-        path = os.path.join(path, "{}C".format(ambient_temp))
+        path = os.path.join(os.path.abspath(path), "{}C".format(ambient_temp))
 
         super().__init__(path, fix)
 

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -13,11 +13,13 @@ from abc import ABC, abstractmethod
 import h5py
 import numpy as np
 import read_acq
+import toml
 from bidict import bidict
 from cached_property import cached_property
 from scipy import io as sio
 
 from . import utils
+from .data import DATA_PATH
 from .logging import logger
 
 LOAD_ALIASES = bidict(
@@ -28,6 +30,9 @@ LOAD_ALIASES = bidict(
         "short": "LongCableShorted",
     }
 )
+
+with open(os.path.join(DATA_PATH, "antenna_simulators.toml")) as fl:
+    ANTENNA_SIMULATORS = toml.load(fl)
 
 
 class _DataFile(ABC):
@@ -143,8 +148,10 @@ class _DataContainer(ABC):
 
 
 class _SpectrumOrResistance(_DataFile):
+    load_pattern = "|".join(LOAD_ALIASES.values())
+    antsim_pattern = "|".join(ANTENNA_SIMULATORS.keys())
     file_pattern = (
-        r"(?P<load_name>%s|AntSim\d)" % ("|".join(LOAD_ALIASES.values()))
+        r"(?P<load_name>%s|%s)" % (load_pattern, antsim_pattern)
         + r"_(?P<run_num>\d{2})_(?P<year>\d{4})_(?P<day>\d{3})_("
         r"?P<hour>\d{2})_(?P<minute>\d{2})_(?P<second>\d{2})_lab.(?P<file_format>\w{2,"
         r"3})$"
@@ -173,48 +180,45 @@ class _SpectrumOrResistance(_DataFile):
             logger.success("Successfully converted to {}".format(newname))
             return os.path.join(root, newname), match
 
-        # Try fixing from standard old format with redundant 25C in it.
-        loads = "|".join(LOAD_ALIASES.values())
-
         bad_patterns = [
             (
-                r"^(?P<load_name>%s|AntSim\d)" % loads
+                r"^(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_25C_(?P<month>\d{1,2})_(?P<day>\d{1,2})_("
                 r"?P<year>\d\d\d\d)_(?P<hour>\d{1,2})_(?P<minute>\d{"
                 r"1,2})_(?P<second>\d{1,2}).(?P<file_format>\w{2,3})$"
             ),
             (
-                "^(?P<load_name>{})".format(loads)
+                "^(?P<load_name>{})".format(cls.load_pattern)
                 + r"(?P<run_num>\d{1,2})_25C_(?P<month>\d{1,"
                 r"2})_(?P<day>\d{1,2})_(?P<year>\d\d\d\d)_("
                 r"?P<hour>\d{1,2})_(?P<minute>\d{1,"
                 r"2})_(?P<second>\d{1,2}).(?P<file_format>\w{2,3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_(?P<year>\d{4})_(?P<day>\d{3})_"
                 r"(?P<hour>\d{2})_(?P<minute>\d{2})_(?P<second>\d{2})_lab."
                 r"(?P<file_format>\w{2,3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_(?P<year>\d{4})_(?P<day>\d{3})_(?P<hour>\d{2}).(?P<file_format>\w{2,3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_(?P<year>\d{4})_(?P<day>\d{3})_(?P<hour>\d{2}).(?P<file_format>\w{2,3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_(?P<year>\d{4})_(?P<day>\d{3})_lab.(?P<file_format>\w{2,3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_(?P<run_num>\d)_(?P<year>\d{4})_(?P<day>\d{3})_lab.(?P<file_format>\w{2,"
                 r"3})$"
             ),
             (
-                r"(?P<load_name>%s|AntSim\d)" % loads
+                r"(?P<load_name>%s|%s)" % (cls.load_pattern, cls.antsim_pattern)
                 + r"_\d{2}C_(?P<month>\d{1,2})_(?P<day>\d{1,2})_(?P<year>\d{4})_(?P<hour>\d{"
                 r"1,2})_(?P<minute>\d{1,2})_(?P<second>\d{1,2}).(?P<file_format>\w{2,3})"
             ),
@@ -342,7 +346,7 @@ class _SpectrumOrResistance(_DataFile):
         if load in LOAD_ALIASES:
             load = LOAD_ALIASES[load]
 
-        if load not in LOAD_ALIASES.values() and not load.startswith("AntSim"):
+        if load not in LOAD_ALIASES.values() and load not in ANTENNA_SIMULATORS:
             logger.error(
                 "The load specified {} is not one of the options available.".format(
                     load
@@ -864,7 +868,7 @@ class LoadS11(_S11SubDir):
 
 
 class AntSimS11(LoadS11):
-    folder_pattern = r"(?P<load_name>AntSim\d)$"
+    folder_pattern = r"(?P<load_name>%s)$" % ("|".join(ANTENNA_SIMULATORS.keys()))
 
 
 class _RepeatNumberableS11SubDir(_S11SubDir):
@@ -894,12 +898,12 @@ class S11Dir(_DataContainer):
     _content_type = {
         **{load: LoadS11 for load in LOAD_ALIASES.values()},
         **{
-            "AntSim": AntSimS11,
             "SwitchingState": SwitchingState,
             "ReceiverReading": ReceiverReading,
             "InternalSwitch": SwitchingState,  # To catch the old way so it can be fixed.
             "LongCableShort": LoadS11,
         },
+        **{key: AntSimS11 for key in ANTENNA_SIMULATORS.keys()},
     }
 
     def __init__(self, path, repeat_num=None, run_num=None, fix=False):
@@ -1001,7 +1005,9 @@ class S11Dir(_DataContainer):
                 [
                     os.path.basename(fl)
                     for fl in fls
-                    if os.path.basename(fl).startswith("AntSim")
+                    if any(
+                        os.path.basename(fl).startswith(k) for k in ANTENNA_SIMULATORS
+                    )
                 ]
             )
         )

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -34,6 +34,11 @@ LOAD_ALIASES = bidict(
 with open(os.path.join(DATA_PATH, "antenna_simulators.toml")) as fl:
     ANTENNA_SIMULATORS = toml.load(fl)
 
+# Dictionary of misspelled:true mappings.
+ANTSIM_REVERSE = {
+    v: k for k, val in ANTENNA_SIMULATORS.items() for v in val.get("misspells", [])
+}
+
 
 class _DataFile(ABC):
     def __init__(self, path, fix=False):
@@ -222,6 +227,11 @@ class _SpectrumOrResistance(_DataFile):
                 + r"_\d{2}C_(?P<month>\d{1,2})_(?P<day>\d{1,2})_(?P<year>\d{4})_(?P<hour>\d{"
                 r"1,2})_(?P<minute>\d{1,2})_(?P<second>\d{1,2}).(?P<file_format>\w{2,3})"
             ),
+            (
+                r"(?P<load_name>%s)" % ("|".join(ANTSIM_REVERSE.keys()))
+                + r"_\d{2}C_(?P<month>\d{1,2})_(?P<day>\d{1,2})_(?P<year>\d{4})_(?P<hour>\d{"
+                r"1,2})_(?P<minute>\d{1,2})_(?P<second>\d{1,2}).(?P<file_format>\w{2,3})"
+            ),
         ]
         i = 0
         while match is None and i < len(bad_patterns):
@@ -257,6 +267,10 @@ class _SpectrumOrResistance(_DataFile):
 
             if "second" not in dct:
                 dct["second"] = "00"
+
+            # Switch Antenna Simulator "misspells" to true form.
+            if dct["load_name"] in ANTSIM_REVERSE:
+                dct["load_name"] = ANTSIM_REVERSE[dct["load_name"]]
 
             newname = (
                 "{load_name}_{run_num:0>2}_{year:0>4}_{jd:0>3}_{hour:0>2}_{minute:0>2}_"
@@ -314,7 +328,7 @@ class _SpectrumOrResistance(_DataFile):
                     logger.error("The minute for {} is outside 0-60!".format(newname))
                 if not (0 <= int(groups["second"]) <= 60):
                     logger.error("The second for {} is outside 0-60!".format(newname))
-                if not groups["file_format"] in cls.supported_formats:
+                if groups["file_format"] not in cls.supported_formats:
                     logger.error(
                         "The file {} is not of a supported format ({}). Got format "
                         "{}".format(
@@ -652,10 +666,7 @@ class _SpectraOrResistanceFolder(_DataContainer):
 
     def read_all(self):
         """Read all spectra"""
-        out = {}
-        for name in LOAD_ALIASES:
-            out[name] = getattr(self, name).read()
-        return out
+        return {name: getattr(self, name).read() for name in LOAD_ALIASES}
 
 
 class Spectra(_SpectraOrResistanceFolder):
@@ -707,13 +718,11 @@ class S1P(_DataFile):
                     "Possible: {}".format(path, groups["kind"], cls.POSSIBLE_KINDS)
                 )
 
-                if fix:
-                    if groups["kind"].capitalize() in cls.POSSIBLE_KINDS:
-                        shutil.move(
-                            path,
-                            os.path.join(os.path.dirname(path), basename.capitalize()),
-                        )
-                        logger.success("Changed to ", basename.capitalize())
+                if fix and groups["kind"].capitalize() in cls.POSSIBLE_KINDS:
+                    shutil.move(
+                        path, os.path.join(os.path.dirname(path), basename.capitalize())
+                    )
+                    logger.success("Changed to ", basename.capitalize())
 
             if int(groups["run_num"]) < 1:
                 logger.error(
@@ -870,6 +879,30 @@ class LoadS11(_S11SubDir):
 class AntSimS11(LoadS11):
     folder_pattern = r"(?P<load_name>%s)$" % ("|".join(ANTENNA_SIMULATORS.keys()))
 
+    @classmethod
+    def check_self(cls, path, fix=False):
+        path, match = super().check_self(path, fix)
+
+        if match is None and fix:
+            bad_patterns = [r"(?P<load_name>%s)$" % ("|".join(ANTSIM_REVERSE.keys()))]
+
+            for pattern in bad_patterns:
+                match = re.search(pattern, os.path.basename(path))
+
+            if match is not None:
+                loadname = match.groupdict()["load_name"]
+
+                if loadname in ANTSIM_REVERSE:
+                    loadname = ANTSIM_REVERSE[loadname]
+
+                newpath = os.path.join(os.path.dirname(path), loadname)
+
+                shutil.move(path, newpath)
+                path = newpath
+                logger.success("Successfully converted to {}".format(path))
+
+        return path, match
+
 
 class _RepeatNumberableS11SubDir(_S11SubDir):
     def __init__(self, direc, run_num=None, fix=False):
@@ -904,6 +937,7 @@ class S11Dir(_DataContainer):
             "LongCableShort": LoadS11,
         },
         **{key: AntSimS11 for key in ANTENNA_SIMULATORS.keys()},
+        **{key: AntSimS11 for key in ANTSIM_REVERSE.keys()},
     }
 
     def __init__(self, path, repeat_num=None, run_num=None, fix=False):
@@ -982,7 +1016,7 @@ class S11Dir(_DataContainer):
         if not os.path.exists(path):
             logger.error("This path does not exist: {}".format(path))
 
-        if not os.path.basename(path) == "S11":
+        if os.path.basename(path) != "S11":
             logger.error("The S11 folder should be called S11")
 
         return path, True

--- a/src/edges_io/utils.py
+++ b/src/edges_io/utils.py
@@ -8,7 +8,7 @@ def get_active_files(path):
     if not os.path.isdir(path):
         raise ValueError("{} is not a directory!".format(path))
     fls = glob.glob(os.path.join(path, "*"))
-    ok_extra_files = ["Notes.txt", "calibration_analysis.ipynb"]
+    ok_extra_files = ["Notes.txt", "calibration_analysis.ipynb", "derived"]
 
     return [
         fl

--- a/src/edges_io/utils.py
+++ b/src/edges_io/utils.py
@@ -8,15 +8,17 @@ def get_active_files(path):
     if not os.path.isdir(path):
         raise ValueError("{} is not a directory!".format(path))
     fls = glob.glob(os.path.join(path, "*"))
+    ok_extra_files = ["Notes.txt", "calibration_analysis.ipynb"]
+
     return [
         fl
         for fl in fls
-        if not fl.endswith(".old") and not os.path.basename(fl) == "Notes.txt"
+        if not fl.endswith(".old") and os.path.basename(fl) not in ok_extra_files
     ]
 
 
 def get_parent_dir(path, n=1):
-    for i in range(n):
+    for _ in range(n):
         path = os.path.dirname(os.path.normpath(path))
     return path
 


### PR DESCRIPTION
Fixes #11  and begins on #15 .

Adds a TOML file for defining our antenna simulators explicitly, and ensures that any simulator found in an observation matches those definitions.

Also ensures the antenna simulators within a particular observation are identified and can be read in more easily.

Also reads in time data (and other metadata) for the Resistance measurements.