### PR TITLE
Dev freq

### DIFF
--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -485,7 +485,7 @@ class Spectrum(_SpectrumOrResistance):
         ):
             raise ValueError("not all file formats are the same!")
         return formats[0]
-    
+
     def read(self):
         """
         Read the files of the object, and concatenate their data.
@@ -523,7 +523,7 @@ class Spectrum(_SpectrumOrResistance):
         """
         # loading data and extracting main array
         d = sio.loadmat(file_name)
-        meta= {}
+        meta = {}
         # Return dict of all things
         if "Qratio" not in d:
             raise IOError(

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -1158,7 +1158,7 @@ class CalibrationObservation(_DataContainer):
 
     def frequencies(self):
         for name, load in LOAD_ALIASES.items():
-            freqs=np.linspace(self.freq_low, self.freq_high, vars(self.spectra)[name].spectra['p0'].shape[0])
+            freqs=np.linspace(0, self.freq_high, vars(self.spectra)[name].spectra['p0'].shape[0])
             setattr(
                 vars(self.spectra)[name],
                 "frequencies",

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -485,7 +485,7 @@ class Spectrum(_SpectrumOrResistance):
         ):
             raise ValueError("not all file formats are the same!")
         return formats[0]
-
+    
     def read(self):
         """
         Read the files of the object, and concatenate their data.
@@ -502,7 +502,7 @@ class Spectrum(_SpectrumOrResistance):
                     out[key] = this_spec[key]
                 else:
                     out[key] = np.concatenate((out[key], this_spec[key]), axis=1)
-
+        setattr(self, 'spectra', out)
         return out
 
     @staticmethod
@@ -1154,3 +1154,13 @@ class CalibrationObservation(_DataContainer):
         """Read all spectra and resistance files."""
         self.spectra.read_all()
         self.resistance.read_all()
+        self.frequencies()
+
+    def frequencies(self):
+        for name, load in LOAD_ALIASES.items():
+            freqs=np.linspace(self.freq_low, self.freq_high, vars(self.spectra)[name].spectra['p0'].shape[0])
+            setattr(
+                vars(self.spectra)[name],
+                "frequencies",
+                freqs
+            )


### PR DESCRIPTION
Metadata is now read from acq and h5 files and is used to fill in frequency information for spectra. The metadata and some ancillary data are placed into each spectra object.