### PR TITLE
Revert erroneous commas in S1P format

### DIFF
--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -889,7 +889,7 @@ class S1P(_DataFile):
                     break
 
         #  loading data
-        d = np.genfromtxt(path_filename, skip_header=comment_rows, delimiter=",")
+        d = np.genfromtxt(path_filename, skip_header=comment_rows)
 
         return d, flag
 


### PR DESCRIPTION
I recently made a change to the `S1P.read()` method which made it assume the delimiter was a comma. This was erroneous, based on badly formatted files that exist on enterprise. Normal well-formatted files are tab-delimited.