### PR TITLE
Fix a bug in reading s11

### DIFF
--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -870,8 +870,10 @@ class S1P(_DataFile):
     @staticmethod
     def _get_kind(path_filename):
         # identifying the format
+
         with open(path_filename, "r") as d:
             comment_rows = 0
+            flag = None
             for line in d.readlines():
                 # checking settings line
                 if line.startswith("#"):
@@ -887,6 +889,14 @@ class S1P(_DataFile):
                     comment_rows += 1
                 elif flag is not None:
                     break
+                else:
+                    warnings.warn(
+                        f"Non standard line in S11 file {path_filename}: '{line}'\n...Treating as a comment line."
+                    )
+                    comment_rows += 1
+
+        if flag is None:
+            raise IOError(f"The file {path_filename} has incorrect format.")
 
         #  loading data
         d = np.genfromtxt(path_filename, skip_header=comment_rows)


### PR DESCRIPTION
Fixes a bug in reading S11 where some files are corrupted slightly and have a comment line that doesn't start with a "!". In this case, it treats it as a comment and issues a warning. 