### PR TITLE
Odt to txt

### DIFF
--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -21,8 +21,8 @@ information silently.
 
 A global exception to this rule are files with the following suffices: ``.old``, ``.invalid``,
 ``.ignore``. These may be kept in the observation and will always be ignored by the
-checker and reader. In addition, a file called ``Notes.txt`` may be placed anywhere
-in the structure.
+checker and reader. In addition, a file called ``Notes.txt`` *should* be placed at the
+root of the structure (i.e. in the ``25C/`` folder).
 
 Throughout the following description, we will use formats such as ``FileXX_YYY.txt``.
 In these, some groups of letters are intended to be placeholders for meta-information.
@@ -180,6 +180,11 @@ which correspond to:
 * ``MAJOR``: backwards-incompatible change. A change such that the reader itself must
   be changed in order to give the same results, or not error. In this case, all
   observations on disk will require updating.
+
+v1.1.0
+~~~~~~
+* Specified that ``Notes.txt`` must be placed in the root folder rather than anywhere
+  in the structure.
 
 v1.0.0
 ~~~~~~

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -11,6 +11,7 @@ import os
 import re
 import read_acq
 import shutil
+import subprocess
 import tempfile
 import toml
 import warnings
@@ -195,9 +196,18 @@ class _DataContainer(ABC):
 
                     if fix:
                         if fl.name == "Notes.odt":
-                            shutil.move(fl, fl.with_suffix(".txt"))
-                            fl = fl.with_suffix(".txt")
-                            logger.success(f"Successfully renamed to {fl}")
+                            try:
+                                subprocess.run(
+                                    [f"pandoc -o {fl.with_suffix('.txt')} {fl}"],
+                                    check=True,
+                                )
+                                fl = fl.with_suffix(".txt")
+                                logger.success(f"Successfully renamed to {fl}")
+                            except subprocess.CalledProcessError as e:
+                                logger.warning(
+                                    f"Could not convert to .txt -- error: {e.message}"
+                                )
+
                         else:
                             fixed = utils._ask_to_rm(fl)
 


### PR DESCRIPTION
Auto-convert legacy `.odt` files to `.txt` so they are readable on the command line.