### PR TITLE
Fix bump-version action

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,8 +1,8 @@
 name: Bump Version
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
 jobs:
   bump-version-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -14,5 +14,5 @@ jobs:
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v4.5
         with:
-          github_token: ${{ secrets.bump_version }}
+          github_token: ${{ secrets.BUMP_VERSION }}
           default_bump: false


### PR DESCRIPTION
The bump-version action is currently showing bad credentials. This attempts to fix that. Might end up having to remove that action.