### PR TITLE
feat: add FieldSpectrum object

### DIFF
--- a/src/edges_io/__init__.py
+++ b/src/edges_io/__init__.py
@@ -10,4 +10,4 @@ finally:
 
 from . import h5, io
 from .h5 import HDF5Object, HDF5RawSpectrum, HDF5StructureError
-from .io import S1P, Spectrum
+from .io import S1P, FieldSpectrum, Spectrum


### PR DESCRIPTION
Adds a `FieldSpectrum` class which knows how to read the ACQ files output in the field, but doesn't check the filename etc. that must be associated with a calibration spectrum.