### PR TITLE
fix: optional function needs to be tagged as such

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     rich
     attrs
     toml
+    dill
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/edges_io/h5.py
+++ b/src/edges_io/h5.py
@@ -279,7 +279,12 @@ class HDF5Object(_HDF5Part):
             if k == "meta" and k not in grp:
                 k = "attrs"
 
-            if k not in grp and k != "attrs" and v != "optional":
+            if (
+                k not in grp
+                and k != "attrs"
+                and v != "optional"
+                and not getattr(v, "optional", False)
+            ):
                 raise TypeError(f"Non-optional key '{k}' not in {grp}")
             elif k == "attrs":
                 if isinstance(grp, (h5py.Group, h5py.File)):

--- a/src/edges_io/h5.py
+++ b/src/edges_io/h5.py
@@ -60,6 +60,14 @@ class _HDF5Part(metaclass=ABCMeta):
 
         return self.__fl_inst
 
+    def __getstate__(self):
+        """Prepare class for pickling. HDF5 files are not pickleable!"""
+        return {
+            key: val
+            for key, val in self.__dict__.items()
+            if not key.endswith("__fl_inst")
+        }
+
     def __contains__(self, item):
         return item in list(self.keys())
 

--- a/src/edges_io/h5.py
+++ b/src/edges_io/h5.py
@@ -63,9 +63,8 @@ class _HDF5Part(metaclass=ABCMeta):
     def __getstate__(self):
         """Prepare class for pickling. HDF5 files are not pickleable!"""
         return {
-            key: val
+            key: (val if not key.endswith("__fl_inst") else None)
             for key, val in self.__dict__.items()
-            if not key.endswith("__fl_inst")
         }
 
     def __contains__(self, item):

--- a/src/edges_io/utils.py
+++ b/src/edges_io/utils.py
@@ -125,6 +125,7 @@ def snake_to_camel(word: str):
 
 
 def optional(fnc):
+    fnc.optional = True
     return lambda x: x is None or fnc(x)
 
 

--- a/src/edges_io/utils.py
+++ b/src/edges_io/utils.py
@@ -125,8 +125,11 @@ def snake_to_camel(word: str):
 
 
 def optional(fnc):
-    fnc.optional = True
-    return lambda x: x is None or fnc(x)
+    def outfnc(x):
+        return x is None or fnc(x)
+
+    outfnc.optional = True
+    return outfnc
 
 
 def isintish(x):

--- a/tests/test_h5object.py
+++ b/tests/test_h5object.py
@@ -1,5 +1,6 @@
 import pytest
 
+import dill as pickle
 import h5py
 import inspect
 import numpy as np
@@ -120,6 +121,15 @@ def test_getitem(fastspec_spectrum_fl):
 
     with pytest.raises(KeyError):
         obj["not_existent"]
+
+
+def test_pickling(fastspec_spectrum_fl):
+    obj = HDF5RawSpectrum(fastspec_spectrum_fl)
+    # ensure we load up the file instance
+    obj._fl_instance
+
+    # see if we can still pickle it...
+    pickle.dumps(obj)
 
 
 def test_bad_existing_h5(tmpdir: Path):


### PR DESCRIPTION
Otherwise non-existing keys will still raise an error when specified with `optional(fnc)`