### PR TITLE
fix: ensure order of spec/therm files is constant

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -37,8 +37,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m pytest --cov=edges_io --cov-config=.coveragerc --cov-report xml:./coverage.xml --durations=25
-      - uses: codecov/codecov-action@master
+      - uses: codecov/codecov-action@1.5.2
         if: matrix.os == 'ubuntu-latest' && success()
         with:
-          token: ${{secrets.CODECOV_TOKEN}} #required
           file: ./coverage.xml #optional

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m pytest --cov=edges_io --cov-config=.coveragerc --cov-report xml:./coverage.xml --durations=25
-      - uses: codecov/codecov-action@1.5.2
+      - uses: codecov/codecov-action@v1.5.2
         if: matrix.os == 'ubuntu-latest' && success()
         with:
           file: ./coverage.xml #optional

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     numpy
     scipy
     h5py
-    read_acq @ git+git://github.com/edges-collab/read_acq.git
+    read_acq
     cached_property
     bidict
     pyyaml

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -221,7 +221,7 @@ class _SpectrumOrResistance(_DataFile):
                 f"The load specified [{load}] is not one of the options available."
             )
 
-        files = list(direc.glob(f"{load}_??_????_???_??_??_??_lab.*"))
+        files = sorted(direc.glob(f"{load}_??_????_???_??_??_??_lab.*"))
 
         if not files:
             raise utils.LoadExistError(
@@ -229,10 +229,7 @@ class _SpectrumOrResistance(_DataFile):
                 f"Found files: {list(files)}."
             )
 
-        if filetype:
-            filetype = [filetype]
-        else:
-            filetype = cls.supported_formats
+        filetype = [filetype] if filetype else cls.supported_formats
 
         # Use any format so long as it is supported
         rfiles = []


### PR DESCRIPTION
This small fix ensures that spec/thermistor files are always read in the same order. Thanks to @nmahesh1412 !