### PR TITLE
fix: enable bump tag secrets

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -14,5 +14,5 @@ jobs:
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v4.5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BUMP_VERSION }}
           default_bump: false


### PR DESCRIPTION
just messing around with letting github deploy to pypi for us