### PR TITLE
feat: Ability to register types as YAML in HDF5Object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 =========
 Changelog
 =========
+v2.5.0
+======
+
+Added
+-----
+
+* Ability to register types as "YAML", so that they can be read from the HDF5 ``attrs``
+  (or "meta") as native types via YAML. This works both ways (i.e. read and write) as
+  long as a constructor/representer is defined for the object in YAML.
 
 v2.4.0
 ======


### PR DESCRIPTION
This enables certain classes to be "registered" so that a `HDF5Object` can load them in from the `.attrs` attribute of a HDF5 file via YAML. The main example in mind would be saving `Model` objects to a file (from `edges-cal`). If they are registered, then one could save a model to the attrs just by putting it in the `.meta` attribute of a `HDF5Object`. When reading the object, instead of reading in as a string, it will read in --- via YAML --- as an actual `Model` object.