### PR TITLE
Remove stale references to HDF5Object instances

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     toml
     dill
     importlib_metadata; python_version<'3.8'
+    psutil
 
 [options.packages.find]
 where = src

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -1802,7 +1802,8 @@ class CalibrationObservation(_DataContainer):
         }
 
         pre_level = logger.level
-        logger.handlers[0].setLevel(100)  # Temporarily disable stdout handler
+        if logger.handlers:
+            logger.handlers[0].setLevel(100)  # Temporarily disable stdout handler
 
         # Add a string buffer handler that can capture the error messages.
         msg_buffer = StringIO()
@@ -1842,7 +1843,8 @@ class CalibrationObservation(_DataContainer):
             raise e
         finally:
             logger.removeHandler(handler)
-            logger.handlers[0].setLevel(pre_level)
+            if logger.handlers:
+                logger.handlers[0].setLevel(pre_level)
 
         return parts
 

--- a/tests/test_h5object.py
+++ b/tests/test_h5object.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 from pathlib import Path
 
 from edges_io.h5 import (
+    _ALL_HDF5OBJECTS,
     HDF5Object,
     HDF5RawSpectrum,
     HDF5StructureExtraKey,
@@ -206,49 +207,49 @@ def test_yaml_attrs(tmpdir: Path):
 def test_memory_leakage_same_file(fastspec_spectrum_fl):
     pr = psutil.Process()
 
+    print(_ALL_HDF5OBJECTS)
+    obj = HDF5RawSpectrum(fastspec_spectrum_fl)
+    obj.clear()  # just in case it's open as a fixture somewhere...
+    print(_ALL_HDF5OBJECTS)
+
     meminfo = [pr.memory_info().rss]
     for i in range(5):
         obj = HDF5RawSpectrum(fastspec_spectrum_fl)
 
-        # Make sure memory grows....
-        obj.spectra["p0"]
-        obj.spectra["p1"]
-        obj.spectra["p2"]
-        obj.spectra["Q"]
+        mem = 0
+        for item in ["p0", "p1", "p2", "Q"]:
+            mem += obj["spectra"][item].size * obj["spectra"][item].itemsize
 
         meminfo.append(pr.memory_info().rss)
 
         if i > 0:
             # Ensure memory is the same for each loop (i.e. previous object is cleared)
-            assert meminfo[-1] <= 1.1 * meminfo[-2]
-        else:
-            # Make sure that the object has memory allocated in it.
-            assert meminfo[1] > 2 * meminfo[0]
+            assert meminfo[-1] - meminfo[-2] < mem / 4
 
 
-def test_memory_leakage_diff_file(tmp_path_factory, fastspec_spectrum_fl: Path):
+def test_memory_leakage_diff_file(tmpdir, fastspec_spectrum_fl: Path):
     pr = psutil.Process()
-
-    newdir = tmp_path_factory.mkdir("memory-leak")
 
     meminfo = [pr.memory_info().rss]
     for i in range(5):
-        newfile = newdir / f"new{i}.h5"
+        newfile = tmpdir / f"new{i}.h5"
         shutil.copy(fastspec_spectrum_fl, newfile)
 
         obj = HDF5RawSpectrum(newfile)
 
         # Make sure memory grows....
-        obj.spectra["p0"]
-        obj.spectra["p1"]
-        obj.spectra["p2"]
-        obj.spectra["Q"]
+        obj["spectra"]["p0"]
+        obj["spectra"]["p1"]
+        obj["spectra"]["p2"]
+        obj["spectra"]["Q"]
+
+        mem = 4 * obj["spectra"]["p0"].size * 8
 
         meminfo.append(pr.memory_info().rss)
 
         if i > 0:
             # Ensure memory is the same for each loop (i.e. previous object is cleared)
-            assert meminfo[-1] <= 1.1 * meminfo[-2]
+            assert meminfo[-1] - meminfo[-2] < mem / 4
         else:
             # Make sure that the object has memory allocated in it.
-            assert meminfo[1] > 2 * meminfo[0]
+            assert meminfo[1] - meminfo[0] >= mem


### PR DESCRIPTION
The `HDF5Object` class was self-referencing, which is not really what you want, because it was stopping it being properly deleted and releasing significant amounts of memory. 

This fixes that by using weakrefs instead of actual references.