### PR TITLE
fix: check if ending lines of S1P files exist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ exclude =
 dev =
     pre-commit
     pytest
-acq =
-    read_acq>=0.4<1.0
 
 
 [options.entry_points]

--- a/src/edges_io/io.py
+++ b/src/edges_io/io.py
@@ -851,7 +851,8 @@ class S1P(_DataFile):
         with open(path_filename) as d:
             comment_rows = 0
             flag = None
-            for line in d.readlines():
+            lines = d.readlines()
+            for line in lines:
                 # checking settings line
                 if line.startswith("#"):
                     if "DB" in line or "dB" in line:
@@ -872,11 +873,21 @@ class S1P(_DataFile):
                     )
                     comment_rows += 1
 
+            # Also check the the last lines for stupid entries like "END"
+            footer_lines = 0
+            for line in lines[::-1]:
+                if line.startswith("#") or ("END" in line) or not line:
+                    footer_lines += 1
+                else:
+                    break
+
         if flag is None:
             raise OSError(f"The file {path_filename} has incorrect format.")
 
         #  loading data
-        d = np.genfromtxt(path_filename, skip_header=comment_rows)
+        d = np.genfromtxt(
+            path_filename, skip_header=comment_rows, skip_footer=footer_lines
+        )
 
         return d, flag
 


### PR DESCRIPTION
Provides a fix for when S1P files have lines like "END" at the end of them.