### PR TITLE
ci: use python 3.11 for downstream tests

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -54,7 +54,7 @@ jobs:
 
   downstream:
     env:
-      PYTHON: 3.8
+      PYTHON: "3.11"
       OS: ubuntu-latest
     name: Downstream
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install coverage
         run: pip install coverage


### PR DESCRIPTION
Upgrades the CI to use python 3.11 for downstream tests