### PR TITLE
fix: import antecedent types

### DIFF
--- a/src/edges_io/types.py
+++ b/src/edges_io/types.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union
 
 from astropy import units
+from pygsdata.types import *
 
 PathLike = Union[str, Path]
 FreqType = units.Quantity["frequency"]


### PR DESCRIPTION
This adds a few more useful types to the edges-io types module, and imports the ones from pygsdata so that `from edges_io import types as tp` contains all the useful types.