### PR TITLE
fix: no warning when VNA line starts with BEGIN

### DIFF
--- a/src/edges_io/vna.py
+++ b/src/edges_io/vna.py
@@ -37,7 +37,7 @@ def _get_s1p_kind(path: Path) -> tuple[np.ndarray, str]:
                         flag = "RI"
 
                     comment_rows += 1
-                elif line.startswith("!"):
+                elif line.startswith(("!", "BEGIN")):
                     comment_rows += 1
                 elif flag is not None:
                     break


### PR DESCRIPTION
Simply adds an extra check to reduce excess warnings for s1p files that have lines beginning with "BEGIN"